### PR TITLE
fix large font-sizes on mobile ios safari in `horizontal` orientation

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,7 @@
 ### Features
 
 ### Fixes
+- fix large font-sizes on mobile ios safari in `horizontal` orientation
 
 ### Deprecations
 

--- a/src/style/dapp-root.scss
+++ b/src/style/dapp-root.scss
@@ -26,6 +26,7 @@ html, body {
   height: 100%;
   margin: 0;
   padding: 0;
+  -webkit-text-size-adjust: none;
 }
 
 iframe.evan-dapp {


### PR DESCRIPTION
- [CORE-698]

[CORE-698]: https://evannetwork.atlassian.net/browse/CORE-698